### PR TITLE
Fixed typo in cloud-config. 

### DIFF
--- a/module/router/templates/userdata.tftpl
+++ b/module/router/templates/userdata.tftpl
@@ -70,7 +70,7 @@ write_files:
             mtu: ${vlan_mtu}
 %{ endfor ~}
     path: /etc/netplan/99-static.yaml
-    permission: '0600'
+    permissions: '0600'
   - content: |
       . {
         cache 30

--- a/module/storage/templates/userdata.tftpl
+++ b/module/storage/templates/userdata.tftpl
@@ -63,7 +63,7 @@ write_files:
             addresses: [ "${storage2_ip}/${storage_prefix}" ]
             mtu: ${storage_mtu}
     path: /etc/netplan/99-static.yaml
-    permission: '0600'
+    permissions: '0600'
 
   - content: |
       PasswordAuthentication yes


### PR DESCRIPTION
This PR fixes a small typo in the cloud-config:
- "permission" was corrected to "permissions"
